### PR TITLE
Replace raw pointers with shared pointers

### DIFF
--- a/include/pyre/database.h
+++ b/include/pyre/database.h
@@ -48,23 +48,26 @@ namespace pyre
 {
     /** \cond IGNORE */
     CLASS_FORWARD(Database);
+    CLASS_FORWARD(Primitive);
+    CLASS_FORWARD(Entry);
+
     /** \endcond */
 
     /** Brief The primitive for spark (pairs of obstacles) **/
     class Primitive
     {
     public:
-        virtual double distance(Primitive *other) = 0;
+        virtual double distance(PrimitivePtr other) = 0;
         virtual std::string getUID() = 0;
         virtual ~Primitive(){};
     };
 
     struct Entry
     {
-        Primitive *key;
+        PrimitivePtr key;
         std::vector<Eigen::VectorXd> value;
-        Entry(Primitive *p);
-        Entry(Primitive *p, std::vector<double> vec);
+        Entry(PrimitivePtr p);
+        Entry(PrimitivePtr p, std::vector<double> vec);
         ~Entry();
     };
 
@@ -73,22 +76,22 @@ namespace pyre
     public:
         Database();
 
-        std::vector<Eigen::VectorXd> vectorize(std::vector<Entry *> entries);
+        std::vector<Eigen::VectorXd> vectorize(std::vector<EntryPtr > entries);
 
         /** \brief adds a single entry to the database structure, combining local samplers of same entries */
-        void add(Entry *e);
+        void add(EntryPtr e);
 
         /** \brief adds many entries in the database structure, combining local samplers of same entries */
-        void add(std::vector<Entry *> entries);
+        void add(std::vector<EntryPtr> entries);
 
         /** \brief Returns the nearest entry in the database */
-        Entry *nearest(Entry *e);
+        EntryPtr nearest(EntryPtr e);
 
         /** \brief Returns the nearest entries within Radius \a r */
-        void nearestR(Entry *e, double r, std::vector<Entry *> &list);
+        void nearestR(EntryPtr e, double r, std::vector<EntryPtr> &list);
 
         /** \brief gets all the entries as a list. */
-        void toList(std::vector<Entry *> &list);
+        void toList(std::vector<EntryPtr> &list);
 
         /** \brief Prints the metrics of the database. */
         void printMetrics(std::ostream &os);
@@ -103,7 +106,7 @@ namespace pyre
         unsigned int size();
 
     private:
-        std::shared_ptr<ompl::NearestNeighbors<Entry *>> nn_;
+        std::shared_ptr<ompl::NearestNeighbors<EntryPtr>> nn_;
         std::unordered_set<std::string> set_;
     };
 }  // namespace pyre

--- a/include/pyre/flame.h
+++ b/include/pyre/flame.h
@@ -60,7 +60,7 @@ namespace pyre
         robowflex::RobotPose pose;  // the pose of the occupancy grid.
         bool ***grid;               // a 3D local occupancy grid.
 
-        double distance(Primitive *other);
+        double distance(PrimitivePtr other);
         std::string getUID();
     };
 
@@ -94,7 +94,7 @@ namespace pyre
          */
         ~Flame();
 
-        std::vector<Entry *>
+        std::vector<EntryPtr>
         processExperience(const robowflex::TrajectoryConstPtr &traj, const robowflex::SceneConstPtr &scene,
                           const robowflex::MotionRequestBuilderConstPtr &request) override;
 
@@ -105,10 +105,10 @@ namespace pyre
                                            const unsigned int size, const double res);
 
         /** \brief gets all the primitives from the current Scene. */
-        std::vector<FlamePrimitive *> extractPrimitives(const robowflex::SceneConstPtr &scene);
+        std::vector<FlamePrimitivePtr> extractPrimitives(const robowflex::SceneConstPtr &scene);
 
         /** \brief Creates the entries for the given primitives. */
-        std::vector<Entry *> createEntries(std::vector<FlamePrimitive *> &primitives,
+        std::vector<EntryPtr> createEntries(std::vector<FlamePrimitivePtr> &primitives,
                                            const robowflex::TrajectoryConstPtr &traj,
                                            const robowflex::SceneConstPtr &scene);
 

--- a/include/pyre/pyre.h
+++ b/include/pyre/pyre.h
@@ -83,7 +83,7 @@ namespace pyre
         Pyre();
 
         /** \brief Process the given experience to pairs of local primitives /local samplers (Entries) */
-        virtual std::vector<Entry *>
+        virtual std::vector<EntryPtr>
         processExperience(const robowflex::TrajectoryConstPtr &traj,  //
                           const robowflex::SceneConstPtr &scene,      //
                           const robowflex::MotionRequestBuilderConstPtr &request) = 0;

--- a/include/pyre/spark.h
+++ b/include/pyre/spark.h
@@ -65,7 +65,7 @@ namespace pyre
         std::pair<robowflex::GeometryPtr, robowflex::GeometryPtr> geometries;  // the geometries in the
         std::pair<robowflex::RobotPose, robowflex::RobotPose> poses;           // the poses of the geometries
         std::pair<std::string, std::string> names;                             // the poses of the geometries
-        double distance(Primitive *other);
+        double distance(PrimitivePtr other);
         std::string getUID();
     };
 
@@ -100,16 +100,16 @@ namespace pyre
          */
         ~Spark();
 
-        std::vector<Entry *>
+        std::vector<EntryPtr>
         processExperience(const robowflex::TrajectoryConstPtr &traj, const robowflex::SceneConstPtr &scene,
                           const robowflex::MotionRequestBuilderConstPtr &request) override;
 
         /** \brief gets all the primitives from the current Scene
          */
-        std::vector<SparkPrimitive *> extractPrimitives(const robowflex::SceneConstPtr &scene);
+        std::vector<SparkPrimitivePtr> extractPrimitives(const robowflex::SceneConstPtr &scene);
 
         /** \brief Creates the entries for the given primitives, */
-        std::vector<Entry *> createEntries(std::vector<SparkPrimitive *> &primitives,
+        std::vector<EntryPtr> createEntries(std::vector<SparkPrimitivePtr> &primitives,
                                            const robowflex::TrajectoryConstPtr &traj,
                                            const robowflex::SceneConstPtr &scene);
 

--- a/include/pyre/yaml.h
+++ b/include/pyre/yaml.h
@@ -65,13 +65,13 @@ namespace pyre
         bool loadDatabase(const DatabasePtr &db, const std::string &filename);
 
         /** \brief Loads entries from a file. Both relative and absolute filenames are acceptable */
-        bool loadEntries(std::vector<Entry *> &entries, const std::string &filename);
+        bool loadEntries(std::vector<EntryPtr> &entries, const std::string &filename);
 
         /** \brief Stores the db in a file. Both relative and absolute filenames are acceptable */
         void storeDatabase(const DatabasePtr &db, const std::string &filename);
 
         /** \brief Stores the entries in a file. Both relative and absolute filenames are acceptable */
-        void storeEntries(const std::vector<Entry *> &vec, const std::string &filename);
+        void storeEntries(const std::vector<EntryPtr> &vec, const std::string &filename);
 
     }  // namespace io
 }  // namespace pyre

--- a/scripts/merge.cpp
+++ b/scripts/merge.cpp
@@ -81,11 +81,11 @@ int main(int argc, char **argv)
 
     for (int index = start; index <= end; index++)
     {
-        std::vector<Entry *> entries_spark;
+        std::vector<EntryPtr> entries_spark;
         io::loadEntries(entries_spark, database + "/sparkdb" + parser::toString(index, dwidth) + ".yaml");
         db_spark->add(entries_spark);
 
-        std::vector<Entry *> entries_flame;
+        std::vector<EntryPtr> entries_flame;
         io::loadEntries(entries_flame, database + "/flamedb" + parser::toString(index, dwidth) + ".yaml");
         db_flame->add(entries_flame);
     }

--- a/scripts/visualize_db.cpp
+++ b/scripts/visualize_db.cpp
@@ -70,7 +70,7 @@ enum Show
     DB = 1,
 };
 
-visualization_msgs::Marker createFlameMarker(FlamePrimitive *prim, Eigen::Vector4d color, rx::RobotPose,
+visualization_msgs::Marker createFlameMarker(FlamePrimitivePtr prim, Eigen::Vector4d color, rx::RobotPose,
                                              Eigen::Vector3d scale)
 {
     visualization_msgs::Marker marker;
@@ -213,14 +213,14 @@ int main(int argc, char **argv)
     {
         auto db = std::make_shared<Database>();
         io::loadDatabase(db, database + ".yaml");
-        std::vector<Entry *> entries;
+        std::vector<EntryPtr> entries;
         db->toList(entries);
 
         for (const auto &e : entries)
         {
             if (algo == Algo::SPARK)
             {
-                auto prim = static_cast<SparkPrimitive *>(e->key);
+                auto prim = std::static_pointer_cast<SparkPrimitive>(e->key);
                 rviz->addGeometryMarker(prim->names.first, prim->geometries.first, "map", prim->poses.first,
                                         voxel_color);
                 rviz->addGeometryMarker(prim->names.first, prim->geometries.first, "map", prim->poses.first,
@@ -232,7 +232,7 @@ int main(int argc, char **argv)
             }
             else if (algo == Algo::FLAME)
             {
-                auto prim = static_cast<FlamePrimitive *>(e->key);
+                auto prim = std::static_pointer_cast<FlamePrimitive>(e->key);
                 auto marker = createFlameMarker(prim, voxel_color, prim->pose,
                                                 {prim->voxel_res, prim->voxel_res, prim->voxel_res});
                 rviz->addMarker(marker, prim->getUID());

--- a/src/yaml.cpp
+++ b/src/yaml.cpp
@@ -139,15 +139,15 @@ namespace
         return robowflex::Geometry::makeBox(dimensions[0], dimensions[1], dimensions[2]);
     }
 
-    Entry *YAMLToEntry(const YAML::Node &e)
+    EntryPtr YAMLToEntry(const YAML::Node &e)
     {
-        Entry *entry;
+        EntryPtr entry;
         if (io::isNode(e["key"]))
         {
             auto key = e["key"];
             if (io::isNode(key["geometries"]))
             {
-                auto *prim = new SparkPrimitive();
+                SparkPrimitivePtr prim = std::make_shared<SparkPrimitive>();
                 if (key["geometries"].IsSequence())
                 {
                     prim->geometries.first = YAMLToGeometry(key["geometries"][0]);
@@ -165,11 +165,11 @@ namespace
                     ROS_ERROR("Poses must be a sequence");
 
                 // Create an entry with this key.
-                entry = new Entry(prim);
+                entry = std::make_shared<Entry>(prim);
             }
             else if (io::isNode(key["grid"]))
             {
-                auto *prim = new FlamePrimitive();
+                FlamePrimitivePtr prim = std::make_shared<FlamePrimitive>();
                 if (io::isNode(key["voxel_res"]))
                     prim->voxel_res = key["voxel_res"].as<double>();
                 else
@@ -190,7 +190,7 @@ namespace
                     ROS_ERROR("Pose node does not exist");
 
                 // Create an entry with this key.
-                entry = new Entry(prim);
+                entry = std::make_shared<Entry>(prim);
             }
             else
                 ROS_ERROR("This primitive is not supported");
@@ -209,7 +209,7 @@ namespace
 
     std::shared_ptr<pyre::Database> YAMLToDB(const YAML::Node &node, const DatabasePtr &db)
     {
-        std::vector<Entry *> entries;
+        std::vector<EntryPtr> entries;
 
         for (const auto &e : node)
             entries.emplace_back(YAMLToEntry(e));
@@ -219,11 +219,11 @@ namespace
         return db;
     }
 
-    void YAMLToAdjMat(const YAML::Node &node, std::vector<std::vector<Entry *>> &adj_mat)
+    void YAMLToAdjMat(const YAML::Node &node, std::vector<std::vector<EntryPtr>> &adj_mat)
     {
         for (const auto &vec : node)
         {
-            std::vector<Entry *> entries;
+            std::vector<EntryPtr> entries;
             for (const auto &e : vec["row"])
                 entries.emplace_back(YAMLToEntry(e));
             adj_mat.emplace_back(entries);
@@ -288,7 +288,7 @@ namespace
         return node;
     }
 
-    const YAML::Node SparkPrimitiveToYAML(const SparkPrimitive *prim)
+    const YAML::Node SparkPrimitiveToYAML(const SparkPrimitivePtr prim)
     {
         YAML::Node node;
         node["geometries"].push_back(GeometryToYAML(prim->geometries.first));
@@ -299,7 +299,7 @@ namespace
         return node;
     }
 
-    const YAML::Node FlamePrimitiveToYAML(const FlamePrimitive *prim)
+    const YAML::Node FlamePrimitiveToYAML(const FlamePrimitivePtr prim)
     {
         YAML::Node node;
         node["voxel_res"] = prim->voxel_res;
@@ -310,14 +310,14 @@ namespace
         return node;
     }
 
-    const YAML::Node EntryToYAML(const Entry *entry)
+    const YAML::Node EntryToYAML(const EntryPtr entry)
     {
         YAML::Node node;
-        auto spark_key = dynamic_cast<SparkPrimitive *>(entry->key);
+        auto spark_key = std::dynamic_pointer_cast<SparkPrimitive>(entry->key);
         if (spark_key)
             node["key"] = SparkPrimitiveToYAML(spark_key);
 
-        auto flame_key = dynamic_cast<FlamePrimitive *>(entry->key);
+        auto flame_key = std::dynamic_pointer_cast<FlamePrimitive>(entry->key);
         if (flame_key)
             node["key"] = FlamePrimitiveToYAML(flame_key);
 
@@ -327,7 +327,7 @@ namespace
         return node;
     }
 
-    const YAML::Node EntryVecToYAML(const std::vector<Entry *> &vec)
+    const YAML::Node EntryVecToYAML(const std::vector<EntryPtr> &vec)
     {
         YAML::Node node;
         for (const auto &entry : vec)
@@ -435,7 +435,7 @@ bool io::loadDatabase(const DatabasePtr &db, const std::string &filename)
     return true;
 }
 
-bool io::loadEntries(std::vector<Entry *> &entries, const std::string &filename)
+bool io::loadEntries(std::vector<EntryPtr> &entries, const std::string &filename)
 {
     const auto &result = io::loadFileToYAML(resolvePath(filename));
 
@@ -472,7 +472,7 @@ void io::storeDatabase(const DatabasePtr &db, const std::string &filename)
     robowflex::IO::createFile(fout, resolvePackage(filename));
     YAML::Emitter out;
 
-    std::vector<Entry *> list;
+    std::vector<EntryPtr> list;
     db->toList(list);
 
     out << YAML::BeginSeq;
@@ -484,7 +484,7 @@ void io::storeDatabase(const DatabasePtr &db, const std::string &filename)
     fout.close();
 }
 
-void io::storeEntries(const std::vector<Entry *> &list, const std::string &filename)
+void io::storeEntries(const std::vector<EntryPtr> &list, const std::string &filename)
 {
     ROS_INFO("Storing Entries list in %s with %lu entries", resolvePackage(filename).c_str(), list.size());
 

--- a/src/yaml.cpp
+++ b/src/yaml.cpp
@@ -288,7 +288,7 @@ namespace
         return node;
     }
 
-    const YAML::Node SparkPrimitiveToYAML(const SparkPrimitivePtr prim)
+    const YAML::Node SparkPrimitiveToYAML(SparkPrimitiveConstPtr prim)
     {
         YAML::Node node;
         node["geometries"].push_back(GeometryToYAML(prim->geometries.first));
@@ -299,7 +299,7 @@ namespace
         return node;
     }
 
-    const YAML::Node FlamePrimitiveToYAML(const FlamePrimitivePtr prim)
+    const YAML::Node FlamePrimitiveToYAML(FlamePrimitiveConstPtr prim)
     {
         YAML::Node node;
         node["voxel_res"] = prim->voxel_res;
@@ -310,7 +310,7 @@ namespace
         return node;
     }
 
-    const YAML::Node EntryToYAML(const EntryPtr entry)
+    const YAML::Node EntryToYAML(EntryConstPtr entry)
     {
         YAML::Node node;
         auto spark_key = std::dynamic_pointer_cast<SparkPrimitive>(entry->key);


### PR DESCRIPTION
- Created shared pointers for Entry, Primitive, FlamePrimitive, SparkPrimitive objects
- Replaced raw pointers to these objects with shared_pointers

Was inspired to do this because of a memory leak in `scripts/process.cpp`, where the Primitive/Entry objects created in each loop weren't properly freed. Using shared pointers to handle the memory allocation and deletion fixes this (and other potential memory issues).